### PR TITLE
Abehjati/add-receive-time-metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-js",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/jest": "^27.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Pyth Network SDK in JS",
   "homepage": "https://pyth.network",
   "main": "lib/index.js",

--- a/src/__tests__/PriceFeed.test.ts
+++ b/src/__tests__/PriceFeed.test.ts
@@ -67,7 +67,7 @@ test("getMetadata returns PriceFeedMetadata as expected", () => {
     metadata: {
       attestation_time: 7,
       emitter_chain: 8,
-      receive_time: 9,
+      price_service_receive_time: 9,
       sequence_number: 10,
       something_else: 11, // Ensuring the code is future compatible.
     },
@@ -79,7 +79,7 @@ test("getMetadata returns PriceFeedMetadata as expected", () => {
     PriceFeedMetadata.fromJson({
       attestation_time: 7,
       emitter_chain: 8,
-      receive_time: 9,
+      price_service_receive_time: 9,
       sequence_number: 10,
     })
   );

--- a/src/__tests__/PriceFeed.test.ts
+++ b/src/__tests__/PriceFeed.test.ts
@@ -67,7 +67,9 @@ test("getMetadata returns PriceFeedMetadata as expected", () => {
     metadata: {
       attestation_time: 7,
       emitter_chain: 8,
-      sequence_number: 9,
+      receive_time: 9,
+      sequence_number: 10,
+      something_else: 11, // Ensuring the code is future compatible.
     },
   };
 
@@ -77,7 +79,8 @@ test("getMetadata returns PriceFeedMetadata as expected", () => {
     PriceFeedMetadata.fromJson({
       attestation_time: 7,
       emitter_chain: 8,
-      sequence_number: 9,
+      receive_time: 9,
+      sequence_number: 10,
     })
   );
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,10 @@ export class PriceFeedMetadata {
    */
   emitterChain: number;
   /**
+   * The time the price was received
+   */
+  receiveTime: number;
+  /**
    * Sequence number of the price
    */
   sequenceNumber: number;
@@ -96,10 +100,12 @@ export class PriceFeedMetadata {
   constructor(metadata: {
     attestationTime: number;
     emitterChain: number;
+    receiveTime: number;
     sequenceNumber: number;
   }) {
     this.attestationTime = metadata.attestationTime;
     this.emitterChain = metadata.emitterChain;
+    this.receiveTime = metadata.receiveTime;
     this.sequenceNumber = metadata.sequenceNumber;
   }
 
@@ -111,6 +117,7 @@ export class PriceFeedMetadata {
     return new PriceFeedMetadata({
       attestationTime: jsonFeed.attestation_time,
       emitterChain: jsonFeed.emitter_chain,
+      receiveTime: jsonFeed.receive_time,
       sequenceNumber: jsonFeed.sequence_number,
     });
   }
@@ -119,6 +126,7 @@ export class PriceFeedMetadata {
     const jsonFeed: JsonPriceFeedMetadata = {
       attestation_time: this.attestationTime,
       emitter_chain: this.emitterChain,
+      receive_time: this.receiveTime,
       sequence_number: this.sequenceNumber,
     };
     // this is done to avoid sending undefined values to the server

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,9 +89,9 @@ export class PriceFeedMetadata {
    */
   emitterChain: number;
   /**
-   * The time the price was received
+   * The time that the price service received the price
    */
-  receiveTime: number;
+  priceServiceReceiveTime: number;
   /**
    * Sequence number of the price
    */
@@ -105,7 +105,7 @@ export class PriceFeedMetadata {
   }) {
     this.attestationTime = metadata.attestationTime;
     this.emitterChain = metadata.emitterChain;
-    this.receiveTime = metadata.receiveTime;
+    this.priceServiceReceiveTime = metadata.receiveTime;
     this.sequenceNumber = metadata.sequenceNumber;
   }
 
@@ -117,7 +117,7 @@ export class PriceFeedMetadata {
     return new PriceFeedMetadata({
       attestationTime: jsonFeed.attestation_time,
       emitterChain: jsonFeed.emitter_chain,
-      receiveTime: jsonFeed.receive_time,
+      receiveTime: jsonFeed.price_service_receive_time,
       sequenceNumber: jsonFeed.sequence_number,
     });
   }
@@ -126,7 +126,7 @@ export class PriceFeedMetadata {
     const jsonFeed: JsonPriceFeedMetadata = {
       attestation_time: this.attestationTime,
       emitter_chain: this.emitterChain,
-      receive_time: this.receiveTime,
+      price_service_receive_time: this.priceServiceReceiveTime,
       sequence_number: this.sequenceNumber,
     };
     // this is done to avoid sending undefined values to the server

--- a/src/schemas/PriceFeed.ts
+++ b/src/schemas/PriceFeed.ts
@@ -66,9 +66,9 @@ export interface PriceFeedMetadata {
    */
   emitter_chain: number;
   /**
-   * The time the price was received
+   * The time that the price service received the price
    */
-  receive_time: number;
+  price_service_receive_time: number;
   /**
    * Sequence number of the price
    */
@@ -277,7 +277,11 @@ const typeMap: any = {
     [
       { json: "attestation_time", js: "attestation_time", typ: 0 },
       { json: "emitter_chain", js: "emitter_chain", typ: 0 },
-      { json: "receive_time", js: "receive_time", typ: 0 },
+      {
+        json: "price_service_receive_time",
+        js: "price_service_receive_time",
+        typ: 0,
+      },
       { json: "sequence_number", js: "sequence_number", typ: 0 },
     ],
     "any"

--- a/src/schemas/PriceFeed.ts
+++ b/src/schemas/PriceFeed.ts
@@ -66,6 +66,10 @@ export interface PriceFeedMetadata {
    */
   emitter_chain: number;
   /**
+   * The time the price was received
+   */
+  receive_time: number;
+  /**
    * Sequence number of the price
    */
   sequence_number: number;
@@ -273,6 +277,7 @@ const typeMap: any = {
     [
       { json: "attestation_time", js: "attestation_time", typ: 0 },
       { json: "emitter_chain", js: "emitter_chain", typ: 0 },
+      { json: "receive_time", js: "receive_time", typ: 0 },
       { json: "sequence_number", js: "sequence_number", typ: 0 },
     ],
     "any"

--- a/src/schemas/price_feed.json
+++ b/src/schemas/price_feed.json
@@ -58,7 +58,7 @@
     "PriceFeedMetadata": {
       "description": "Represents metadata of a price feed.",
       "type": "object",
-      "required": ["attestation_time", "emitter_chain", "receive_time", "sequence_number"],
+      "required": ["attestation_time", "emitter_chain", "price_service_receive_time", "sequence_number"],
       "properties": {
         "attestation_time": {
           "description": "Attestation time of the price",
@@ -70,8 +70,8 @@
           "type": "integer",
           "format": "int16"
         },
-        "receive_time": {
-          "description": "The time the price was received",
+        "price_service_receive_time": {
+          "description": "The time that the price service received the price",
           "type": "integer",
           "format": "int64"
         },

--- a/src/schemas/price_feed.json
+++ b/src/schemas/price_feed.json
@@ -58,7 +58,7 @@
     "PriceFeedMetadata": {
       "description": "Represents metadata of a price feed.",
       "type": "object",
-      "required": ["attestation_time", "emitter_chain", "sequence_number"],
+      "required": ["attestation_time", "emitter_chain", "receive_time", "sequence_number"],
       "properties": {
         "attestation_time": {
           "description": "Attestation time of the price",
@@ -69,6 +69,11 @@
           "description": "Chain of the emitter",
           "type": "integer",
           "format": "int16"
+        },
+        "receive_time": {
+          "description": "The time the price was received",
+          "type": "integer",
+          "format": "int64"
         },
         "sequence_number": {
           "description": "Sequence number of the price",


### PR DESCRIPTION
This PR adds `priceServiceReceiveTime` to the metadata of a PriceFeed which is gonna represent when the price was received by the price service.

I added a test to make sure the change is future compatible and does not break our running code. 